### PR TITLE
Fix form validation error that occurs when multiple buttons are present in the form element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Balanz.io",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/public/todos.html
+++ b/public/todos.html
@@ -84,7 +84,7 @@
             
 
             <div class="add-modal-btns">
-                <button class="cancel-btn-add-modal" onclick="closeAddEditModal()">Cancel</button>
+                <button type="button" class="cancel-btn-add-modal" onclick="closeAddEditModal()">Cancel</button>
                 <button class="submit-btn" onclick="saveAddEditModal()">Save Task</button>
             </div>
 


### PR DESCRIPTION
**PR Comment**: 
This PR resolves the issue where pressing "Add Todo" in the popup triggers "fields required" errors. Pressing Enter afterward closes the form and logs the "Invalid form control is not focusable" error in the console.

### Steps to reproduce the bug:
1. Open the popup.
2. Click "Add Todo" without filling the fields.
3. Press Enter.

**Browsers tested on/OS**: Brave, Chrome, Arc and Safari / macOS
**Expected**: Form should stay open and prompt for required fields.  
**Actual**: Form closes with "not focusable" error. Check Console for the errors

**Fix:** 
Since the default value of the type attribute of a button is submit, specifying the type attribute as a button fixes the issue which is done in this PR.

**Before Fix:**
<img width="1904" alt="Screenshot 2024-10-03 at 6 41 20 PM" src="https://github.com/user-attachments/assets/a8401ba7-2e95-46c9-b85d-2a11dd4c958d">

**After Fix:**
<img width="1904" alt="Screenshot 2024-10-03 at 6 45 54 PM" src="https://github.com/user-attachments/assets/16903bc0-4d68-40df-bfe3-cab8db7ebe5c">

